### PR TITLE
Configure graceful shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+node_modules/

--- a/server.js
+++ b/server.js
@@ -2,15 +2,30 @@
 
 const express = require('express');
 
-// Constants
 const PORT = 8081;
 const HOST = '0.0.0.0';
 
-// App
 const app = express();
 app.get('/', (req, res) => {
-  res.send('Hello World');
+    res.send('Hello World');
 });
 
-app.listen(PORT, HOST);
+const server = app.listen(PORT, HOST);
 console.log(`Running on http://${HOST}:${PORT}`);
+
+const signalHandler = (signal) => () => {
+  console.log(`Received ${signal}, stopping server`)
+  server.close((error) => {
+    let exitCode = 0;
+    if (error) {
+      console.error('Error occurred stopping server', error);
+      exitCode = 1;
+    }
+
+    process.exit(exitCode)
+  });
+};
+
+['SIGINT', 'SIGTERM'].forEach((signal) => {
+    process.on(signal, signalHandler(signal));
+});


### PR DESCRIPTION
I was working on getting the demo to deploy successfully and I noticed that the application does not seem to handle signals. 

This isn't usually a problem running locally, but in a container it's the first process and should handle them. Otherwise they're ignored and in Kubernetes the container takes the whole `terminationGracePeriod` to stop, even if it may have quit faster.

This adds a simple signal handler for `SIGINT`/`SIGTERM`. It's possible to test this out locally by building and running the app -- should have the following results:

Before:
```bash
docker run -p 8081:8081 -it demo-app
Running on http://0.0.0.0:8081
^C^C^C^C^C^C^C # sending SIGINT is ignored
```

After:
```bash
 docker run -p 8081:8081 -it demo-app
Running on http://0.0.0.0:8081
^CReceived SIGINT, stopping server
```