### PR TITLE
use more descriptive image tags when building images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Create Docker Tag
         id: tag
         run: |
-          echo "::set-output name=tag::$(git rev-parse --short HEAD)"
+          echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/heads/})-$(git rev-parse --short HEAD)"
 
       - name: Login to Harbor
         uses: docker/login-action@v1.9.0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                 container('git') {
                     script {
                         sh(script: "date -u +'%Y-%m-%dT%H:%M:%SZ' > build-start", returnStdout: true).trim()
-                        tag = sh(script: 'git rev-parse --short HEAD > image-tag && cat image-tag', returnStdout: true).trim()
+                        tag = sh(script: 'git rev-parse --short HEAD > image-tag && echo "$GIT_BRANCH-`cat image-tag`"', returnStdout: true).trim()
                     }
                 }
                 container('kaniko') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                 container('git') {
                     script {
                         sh(script: "date -u +'%Y-%m-%dT%H:%M:%SZ' > build-start", returnStdout: true).trim()
-                        tag = sh(script: 'echo "$GIT_BRANCH-$(git rev-parse --short HEAD)" > image-tag && echo cat image-tag', returnStdout: true).trim()
+                        tag = sh(script: 'echo "$GIT_BRANCH-$(git rev-parse --short HEAD)" > image-tag && cat image-tag', returnStdout: true).trim()
                     }
                 }
                 container('kaniko') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                 container('git') {
                     script {
                         sh(script: "date -u +'%Y-%m-%dT%H:%M:%SZ' > build-start", returnStdout: true).trim()
-                        tag = sh(script: 'git rev-parse --short HEAD > image-tag && echo "$GIT_BRANCH-`cat image-tag`"', returnStdout: true).trim()
+                        tag = sh(script: 'echo "$GIT_BRANCH-$(git rev-parse --short HEAD)" > image-tag && echo cat image-tag', returnStdout: true).trim()
                     }
                 }
                 container('kaniko') {


### PR DESCRIPTION
this PR prepends the image tags with the branch name, so it's easier to tell which resources you're working with in the UI.

for example, the image tag for this PR was `descriptive-tags-0a7019b`. for main, it would be something like `main-abcd123`