### PR TITLE
Adding manual deployment flag for branch-built images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,11 @@ name: Build & Deploy demo-app
 
 on:
   workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Update Deploy Repo Manifest'     
+        required: true
+        default: 'false'
   push:
 
 env:
@@ -70,7 +75,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy == 'true' }}
     runs-on:
       - self-hosted
       - rode-runners-prod


### PR DESCRIPTION
This change enables us to **deploy** from non-main branches by updating the deployment repo manifest from any manual workflow run.
![image](https://user-images.githubusercontent.com/2799387/126382129-39c9c88c-c09a-43b1-9674-981cbc9462e2.png)
