### PR TITLE
Use shared services environment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
   push:
 
 env:
-  BUILD_COLLECTOR_HOST: 'rode-collector-build.rode.svc.cluster.local:8082'
+  BUILD_COLLECTOR_HOST: 'build-collector-grpc.services.liatr.io:443'
   HARBOR_HOST: 'harbor.services.liatr.io'
   SONAR_HOST: 'https://sonarqube.services.liatr.io'
   IMAGE: 'liatrio/rode-demo-node-app'
@@ -21,9 +21,7 @@ env:
 
 jobs:
   build:
-    runs-on:
-      - self-hosted
-      - liatrio-runners-sharedsvc
+    runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     environment: liatrio-sharedsvc
@@ -88,9 +86,7 @@ jobs:
 
   deploy:
     if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy == 'true' }}
-    runs-on:
-      - self-hosted
-      - liatrio-runners-sharedsvc
+    runs-on: ubuntu-latest
     environment: liatrio-sharedsvc
     needs:
       - build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,14 +16,14 @@ env:
   IMAGE: 'liatrio/rode-demo-node-app'
   DEPLOY_REPO: 'rode/demo-app-deployment'
   DEPLOY_REPO_BRANCH: 'dev'
-  OAUTH2_TOKEN_URL: 'https://keycloak.services.liatr.io/auth/realms/rode-demo/protocol/openid-connect/token'
+  OAUTH2_TOKEN_URL: 'https://keycloak.services.liatr.io/auth/realms/liatrio/protocol/openid-connect/token'
   OAUTH2_CLIENT_ID: rode-collector
 
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.image.outputs.digest }}
     environment: liatrio-sharedsvc
     steps:
       - name: Checkout Code
@@ -56,6 +56,15 @@ jobs:
           tags: |
             ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
 
+      - name: Determine Repo Digest
+        id: image
+        run: |
+          set -eu
+          imageDigest=$(docker inspect --format='{{index .RepoDigests 0}}' \
+              ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }})
+
+          echo "::set-output name=digest::${imageDigest}"
+
       - name: Fetch Access Token
         uses: liatrio/github-actions/oauth2-token@master
         id: token
@@ -69,7 +78,7 @@ jobs:
         id: rode
         with:
           accessToken: ${{ steps.token.outputs.accessToken }}
-          artifactId: ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}@${{ steps.docker.outputs.digest }}
+          artifactId: ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}@${{ steps.image.outputs.digest }}
           artifactNames: |
             ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
           buildCollectorHost: ${{ env.BUILD_COLLECTOR_HOST }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,6 @@ jobs:
           artifactNames: |
             ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
           buildCollectorHost: ${{ env.BUILD_COLLECTOR_HOST }}
-          buildCollectorInsecure: true
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,9 +60,10 @@ jobs:
         id: image
         run: |
           set -eu
-          imageDigest=$(docker inspect --format='{{index .RepoDigests 0}}' \
-              ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }})
+          image=${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+          imageDigest=$(docker inspect --format='{{index .RepoDigests 0}}' $image | cut -d'@' -f2)
 
+          echo "Image $image has repo digest $imageDigest"
           echo "::set-output name=digest::${imageDigest}"
 
       - name: Fetch Access Token

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,13 +10,13 @@ on:
   push:
 
 env:
-  BUILD_COLLECTOR_HOST: 'rode-collector-build.rode-demo.svc.cluster.local:8082'
-  HARBOR_HOST: 'harbor.internal.lead.prod.liatr.io'
-  SONAR_HOST: 'https://sonarqube.internal.lead.prod.liatr.io'
-  IMAGE: 'rode-demo/rode-demo-node-app'
+  BUILD_COLLECTOR_HOST: 'rode-collector-build.rode.svc.cluster.local:8082'
+  HARBOR_HOST: 'harbor.services.liatr.io'
+  SONAR_HOST: 'https://sonarqube.services.liatr.io'
+  IMAGE: 'liatrio/rode-demo-node-app'
   DEPLOY_REPO: 'rode/demo-app-deployment'
   DEPLOY_REPO_BRANCH: 'dev'
-  OAUTH2_TOKEN_URL: 'https://keycloak.internal.lead.prod.liatr.io/auth/realms/rode-demo/protocol/openid-connect/token'
+  OAUTH2_TOKEN_URL: 'https://keycloak.services.liatr.io/auth/realms/rode-demo/protocol/openid-connect/token'
   OAUTH2_CLIENT_ID: rode-collector
 
 jobs:
@@ -26,6 +26,7 @@ jobs:
       - liatrio-runners-sharedsvc
     outputs:
       digest: ${{ steps.build.outputs.digest }}
+    environment: liatrio-sharedsvc
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -90,6 +91,7 @@ jobs:
     runs-on:
       - self-hosted
       - liatrio-runners-sharedsvc
+    environment: liatrio-sharedsvc
     needs:
       - build
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,22 +47,14 @@ jobs:
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
 
-      - name: Build and Push
-        id: build
-        run: |
-          cp $HOME/.docker/config.json config.json
-          trap "rm config.json" EXIT
-
-          docker run \
-            -v $(pwd):/workspace \
-            -v $(pwd)/config.json:/kaniko/.docker/config.json:ro \
-            gcr.io/kaniko-project/executor:v1.6.0 \
-              --context dir:///workspace/ \
-              --skip-tls-verify \
-              --digest-file image \
-              -d ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
-
-          echo "::set-output name=digest::$(cat image)"
+      - name: Build and Push Image
+        id: docker
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
 
       - name: Fetch Access Token
         uses: liatrio/github-actions/oauth2-token@master
@@ -77,7 +69,7 @@ jobs:
         id: rode
         with:
           accessToken: ${{ steps.token.outputs.accessToken }}
-          artifactId: ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          artifactId: ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}@${{ steps.docker.outputs.digest }}
           artifactNames: |
             ${{ env.HARBOR_HOST }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
           buildCollectorHost: ${{ env.BUILD_COLLECTOR_HOST }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on:
       - self-hosted
-      - rode-runners-prod
+      - liatrio-runners-sharedsvc
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -89,7 +89,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy == 'true' }}
     runs-on:
       - self-hosted
-      - rode-runners-prod
+      - liatrio-runners-sharedsvc
     needs:
       - build
     steps:


### PR DESCRIPTION
Points the workflow at the shared services Rode instance instead of the demo environment. Also uses the public runners, since we can use the external URLs. 

I also changed the jobs to reference environments instead of relying on repository-level secrets. 